### PR TITLE
Fix file extension detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 _tmp/
 .gows*
+bin/
+steps-create-zip
+README.md.backup

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 <details>
 <summary>Outputs</summary>
-There are no outputs defined in this step
+
+| Environment Variable | Description |
+| --- | --- |
+| `BITRISE_ZIP_PATH` | Absolute path of the ZIP file produced by the Step.  This is the destination path after any normalization the Step applies, such as appending `.zip` when omitted or joining the source's basename when the destination is an existing directory. |
 </details>
 
 ## 🙋 Contributing

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -21,7 +21,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            unzip folder_to_zip_test.zip -d ./folder_to_zip_test_unzipped
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/folder_to_zip_test.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./folder_to_zip_test_unzipped
             diff -r ./folder_to_zip_test ./folder_to_zip_test_unzipped/folder_to_zip_test
 
   test_folder_in_folder:
@@ -43,7 +45,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            unzip test_folder_in_folder.zip -d ./test_folder_in_folder_unzipped
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/test_folder_in_folder.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./test_folder_in_folder_unzipped
             diff -r ./test_folder_in_folder ./test_folder_in_folder_unzipped/test_folder_in_folder
 
   test_file_in_folder:
@@ -67,7 +71,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            unzip test_file_in_folder.zip -d ./test_file_in_folder_unzipped
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/test_file_in_folder.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./test_file_in_folder_unzipped
             diff -r ./test_file_in_folder ./test_file_in_folder_unzipped/test_file_in_folder
 
   test_symlink:
@@ -94,7 +100,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            unzip test_symlink.zip -d ./test_symlink_unzipped
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/test_symlink.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./test_symlink_unzipped
 
             # Symlink target preserved verbatim (test that the step stores the symlink as-is, without dereferencing)
             [ "$(readlink ./test_symlink/symlink_file_test.txt)" = "$(readlink ./test_symlink_unzipped/test_symlink/symlink_file_test.txt)" ]
@@ -126,7 +134,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            unzip ./test_nested_symlink.zip -d ./test_nested_symlink_unzipped
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/test_nested_symlink.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./test_nested_symlink_unzipped
 
             [ "$(readlink ./test_nested_symlink/symlink_file.txt)" = "$(readlink ./test_nested_symlink_unzipped/test_nested_symlink/symlink_file.txt)" ]
 
@@ -152,7 +162,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            unzip ./complex_folder/folder_structure.apk.zip -d ./unzipped_complex_folder
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/complex_folder/folder_structure.apk.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./unzipped_complex_folder
             diff -r ./folder_structure.apk ./unzipped_complex_folder/folder_structure.apk
 
   test_file_only:
@@ -173,8 +185,10 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            set -e
-            unzip ./test_file_only.zip -d ./test_file_only_unzipped
+            set -ex
+            [ "$BITRISE_ZIP_PATH" = "$(pwd)/test_file_only.zip" ]
+            [ -f "$BITRISE_ZIP_PATH" ]
+            unzip "$BITRISE_ZIP_PATH" -d ./test_file_only_unzipped
             diff ./file_only.txt ./test_file_only_unzipped/file_only.txt
 
   _setup:

--- a/main.go
+++ b/main.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bitrise-io/go-steputils/stepconf"
+	"github.com/bitrise-io/go-steputils/tools"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/ziputil"
-	"github.com/bitrise-io/go-steputils/stepconf"
 )
 
 type config struct {
@@ -39,6 +40,13 @@ func main() {
 		failf("Issue with compress: %s", err)
 	}
 
+	absDestination, err := filepath.Abs(destination)
+	if err != nil {
+		failf("Failed to resolve absolute path of %s: %s", destination, err)
+	}
+	if err := tools.ExportEnvironmentWithEnvman("BITRISE_ZIP_PATH", absDestination); err != nil {
+		failf("Failed to export output BITRISE_ZIP_PATH: %s", err)
+	}
 }
 
 func ensureZIP(sourcePath string, destination string) error {
@@ -124,7 +132,7 @@ func checkDestinationIsDir(destination string) (bool, error) {
 	return info.IsDir(), nil
 }
 
-func failf(format string, v ...interface{}) {
+func failf(format string, v ...any) {
 	log.Errorf(format, v...)
 	os.Exit(1)
 }

--- a/main.go
+++ b/main.go
@@ -92,8 +92,10 @@ func fixDestination(destination string, sourcePath string) (string, error) {
 
 	if isDir {
 		destination = filepath.Join(destination, filepath.Base(sourcePath))
+		destination = fixDestinationExt(destination)
+	} else if filepath.Ext(destination) == "" {
+		destination += ".zip"
 	}
-	destination = fixDestinationExt(destination)
 
 	return destination, nil
 }

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func cleanDestination(destination string) string {
 }
 
 func fixDestinationExt(destination string) string {
-	if filepath.Ext(destination) != "zip" {
+	if filepath.Ext(destination) != ".zip" {
 		destination += ".zip"
 	}
 	return destination

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFixDestination(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, base string) (destination string, sourcePath string)
+		wantSuffix string
+	}{
+		{
+			name: "appends .zip when destination has no extension",
+			setup: func(t *testing.T, base string) (string, string) {
+				return filepath.Join(base, "archive"), filepath.Join(base, "src")
+			},
+			wantSuffix: "archive.zip",
+		},
+		{
+			name: "keeps single .zip when destination already ends in .zip",
+			setup: func(t *testing.T, base string) (string, string) {
+				return filepath.Join(base, "archive.zip"), filepath.Join(base, "src")
+			},
+			wantSuffix: "archive.zip",
+		},
+		{
+			name: "joins source basename when destination is an existing directory",
+			setup: func(t *testing.T, base string) (string, string) {
+				dst := filepath.Join(base, "out")
+				if err := os.MkdirAll(dst, 0755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				return dst, filepath.Join(base, "src")
+			},
+			wantSuffix: filepath.Join("out", "src.zip"),
+		},
+		{
+			name: "preserves source basename extension when joining into a directory",
+			setup: func(t *testing.T, base string) (string, string) {
+				dst := filepath.Join(base, "out")
+				if err := os.MkdirAll(dst, 0755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				return dst, filepath.Join(base, "folder_structure.apk")
+			},
+			wantSuffix: filepath.Join("out", "folder_structure.apk.zip"),
+		},
+		{
+			name: "cleans the destination path",
+			setup: func(t *testing.T, base string) (string, string) {
+				return filepath.Join(base, "sub", "..", "archive.zip"), filepath.Join(base, "src")
+			},
+			wantSuffix: "archive.zip",
+		},
+		{
+			name: "creates missing parent directory",
+			setup: func(t *testing.T, base string) (string, string) {
+				return filepath.Join(base, "new", "nested", "archive.zip"), filepath.Join(base, "src")
+			},
+			wantSuffix: filepath.Join("new", "nested", "archive.zip"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			destination, sourcePath := tc.setup(t, base)
+
+			got, err := fixDestination(destination, sourcePath)
+			if err != nil {
+				t.Fatalf("fixDestination returned error: %v", err)
+			}
+
+			want := filepath.Join(base, tc.wantSuffix)
+			if got != want {
+				t.Errorf("fixDestination(%q, %q) = %q, want %q", destination, sourcePath, got, want)
+			}
+
+			if _, err := os.Stat(filepath.Dir(got)); err != nil {
+				t.Errorf("parent directory of result was not created: %v", err)
+			}
+		})
+	}
+}
+
+func TestFixDestinationExt(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"archive", "archive.zip"},
+		{"archive.zip", "archive.zip"},
+		{"folder.apk", "folder.apk.zip"},
+		{"path/to/archive", "path/to/archive.zip"},
+		{"path/to/archive.zip", "path/to/archive.zip"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := fixDestinationExt(tc.in); got != tc.want {
+				t.Errorf("fixDestinationExt(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -27,6 +27,13 @@ func TestFixDestination(t *testing.T) {
 			wantSuffix: "archive.zip",
 		},
 		{
+			name: "respects an explicit non-zip extension on the destination",
+			setup: func(t *testing.T, base string) (string, string) {
+				return filepath.Join(base, "archive.tar"), filepath.Join(base, "src")
+			},
+			wantSuffix: "archive.tar",
+		},
+		{
 			name: "joins source basename when destination is an existing directory",
 			setup: func(t *testing.T, base string) (string, string) {
 				dst := filepath.Join(base, "out")

--- a/step.yml
+++ b/step.yml
@@ -59,3 +59,15 @@ inputs:
     is_expand: true
     is_required: true
     value_options: []
+
+outputs:
+- BITRISE_ZIP_PATH:
+  opts:
+    title: Path of the created ZIP archive
+    summary: Absolute path of the ZIP file produced by the Step.
+    description: |-
+      Absolute path of the ZIP file produced by the Step.
+
+      This is the destination path after any normalization the Step applies,
+      such as appending `.zip` when omitted or joining the source's basename
+      when the destination is an existing directory.

--- a/vendor/github.com/bitrise-io/go-steputils/tools/tools.go
+++ b/vendor/github.com/bitrise-io/go-steputils/tools/tools.go
@@ -1,0 +1,14 @@
+package tools
+
+import (
+	"strings"
+
+	"github.com/bitrise-io/go-utils/command"
+)
+
+// ExportEnvironmentWithEnvman ...
+func ExportEnvironmentWithEnvman(key, value string) error {
+	cmd := command.New("envman", "add", "--key", key)
+	cmd.SetStdin(strings.NewReader(value))
+	return cmd.Run()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,7 @@
 # github.com/bitrise-io/go-steputils v1.0.6
 ## explicit; go 1.15
 github.com/bitrise-io/go-steputils/stepconf
+github.com/bitrise-io/go-steputils/tools
 # github.com/bitrise-io/go-utils v1.0.15
 ## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *Major* [version update](https://semver.org/) — destination path changed.

### Context

<!---
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Takes on the fix from community PR #14: `fixDestinationExt` compared `filepath.Ext(destination)` (which returns the extension *with* the leading dot, e.g. `.zip`) against the literal string `"zip"` (no dot), so the comparison was always true and `.zip` was unconditionally appended — yielding `archive.zip.zip` when the user already supplied `archive.zip`. While in the same area, the Step also stops clobbering user-supplied non-`.zip` extensions, and gains a `BITRISE_ZIP_PATH` output so downstream Steps can consume the produced archive path without re-deriving it.

Fixes: https://github.com/bitrise-steplib/steps-create-zip/pull/14

### Changes

<!--
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

- `fixDestinationExt` now compares against `".zip"` (with the leading dot), matching the actual return value of `filepath.Ext`. No more double `.zip` extension.
- `fixDestination` now appends `.zip` only when the destination has **no** extension at all (instead of any extension other than `.zip`). An explicit `archive.tar` is preserved as `archive.tar` rather than rewritten to `archive.tar.zip`. The directory branch is unchanged: a directory destination still joins the source basename and ensures a `.zip` suffix.
- Added a new `BITRISE_ZIP_PATH` output exposing the **absolute** path of the produced archive (resolved with `filepath.Abs` after the Step's destination normalization — extension appending, basename joining when destination is an existing directory).
- Added unit tests for `fixDestination` / `fixDestinationExt` covering the regression, the new "respect explicit extension" contract, and the directory/basename/cleaning cases.
- e2e tests now assert `$BITRISE_ZIP_PATH` equals `$(pwd)/<expected>` and points to an existing file, then use it as the unzip source so the env is exercised end-to-end.
- README regenerated to reflect the new output.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

- `filepath.Ext` semantics: https://pkg.go.dev/path/filepath#Ext — returns the suffix beginning at the final dot, e.g. `.zip`, not `zip`.

### Decisions

<!-- Please list decisions that were made for this change. -->

- Treat any user-supplied extension as intentional. The step.yml description already promises `.zip` is added "automatically if it was omitted"; this aligns implementation with the documented contract.
- Export the destination as **absolute** rather than passing through whatever the user supplied. Step inputs are commonly relative to the Step's working directory, which is ambiguous for downstream consumers; an absolute path is unambiguous regardless of where the next Step `cd`s to.
- Output name `BITRISE_ZIP_PATH` follows the `BITRISE_*` convention used by other Steps for top-level outputs.